### PR TITLE
Added LED status with ticker library

### DIFF
--- a/src/mitsubishi2mqtt/config.h
+++ b/src/mitsubishi2mqtt/config.h
@@ -49,8 +49,7 @@ const char* max_temp                    = "31"; // Maximum temperature, check va
 const char* temp_step                   = "1"; // Temperature setting step, check value from heatpump remote control
 
 // pinouts
-const int redLedPin  = 0; // Onboard LED = digital pin 0 (red LED on adafruit ESP8266 huzzah)
-const int blueLedPin = 2; // Onboard LED = digital pin 0 (blue LED on adafruit ESP8266 huzzah)
+const int blueLedPin = 2; // Onboard LED = digital pin 2 "D4" (blue LED on WEMOS D1-Mini)
 
 // sketch settings
 const unsigned int SEND_ROOM_TEMP_INTERVAL_MS = 30000;

--- a/src/mitsubishi2mqtt/web_interface.h
+++ b/src/mitsubishi2mqtt/web_interface.h
@@ -12,14 +12,14 @@ String html_header = R"====(
     select{width:100%;}
     textarea{resize:none;width:98%;height:318px;padding:5px;overflow:auto;}
     body{text-align:center;font-family:verdana;}
-    td{padding:0px;}button{border:0;border-radius:0.3rem;background-color:#1fa3ec;color:#fff;line-height:2.4rem;font-size:1.2rem;width:100%;-webkit-transition-duration:0.4s;transition-duration:0.4s;cursor:pointer;}button:hover{background-color:#0e70a4;}.bred{background-color:#d43535;}.bred:hover{background-color:#931f1f;}.bgrn{background-color:#47c266;}.bgrn:hover{background-color:#5aaf6f;}a{text-decoration:none;}.p{float:left;text-align:left;}.q{float:right;text-align:right;}
+    td{padding:0px;}button{text-shadow: 2px 2px 5px black;box-shadow: 0 15px 6px -6px grey;border:0;border-radius:25px;background-color:#1fa3ec;color:#fff;line-height:2.4rem;font-size:1.2rem;width:100%;-webkit-transition-duration:0.4s;transition-duration:0.8s;cursor:pointer;}button:hover{background-color:#0e70a4;}.bred{background-color:#d43535;}.bred:hover{background-color:#931f1f;}.bgrn{background-color:#47c266;}.bgrn:hover{background-color:#5aaf6f;}a{text-decoration:none;}.p{float:left;text-align:left;}.q{float:right;text-align:right;}
   </style>
   </head>
 )====";
 
 String html_footer = R"====(
   <br/>
-    <div style='text-align:right;font-size:11px;'>
+    <div style='text-align:right;font-size:10px;color: grey;'>
       <hr/>Mitsubishi2MQTT _VERSION_ by Gysmo</div></div></body></html>
 )====";
 


### PR DESCRIPTION
Hi Gysmo.

Im not a real good coding expert, but I needed some kind of LED status to the project.

I added the Ticker library (taken from an example of the wifimanager library made by tzapu).

On my setup I use a Wemos D1 mini and the blue onboard LED is on pin 2 (D4). With this ticker library I did it that way, so it blinks rapidly when the Captive portal is ready and blinks slow until then. When the wifi credentials are put in and accepted the ticker detaches and the LED stays on.

Can it be used?

And then I fixed a little typo and deleted the old LED pins in the config, which was not used in the .ino file:)

Best regards

Jacob 

Denmark