### PR TITLE
Replace deprecated SPIFFS with LittleFS

### DIFF
--- a/src/mitsubishi2mqtt/config.h
+++ b/src/mitsubishi2mqtt/config.h
@@ -22,7 +22,7 @@ const PROGMEM char* m2mqtt_version = "0.7.3";
 #ifdef ESP32
 const PROGMEM char* wifi_conf = "/wifi.json";
 const PROGMEM char* mqtt_conf = "/mqtt.json";
-const PROGMEM char* advance_conf = "/advance.json";
+const PROGMEM char* unit_conf = "/unit.json";
 const PROGMEM char* console_file = "/console.log";
 const PROGMEM char* others_conf = "/others.json";
 // pinouts

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -20,15 +20,16 @@
 #include <WiFiUdp.h>
 #include <ESPmDNS.h>          // mDNS for ESP32
 #include <WebServer.h>        // webServer for ESP32
-#include "LittleFS.h"           // ESP32 SPIFFS for store config
-WebServer server(80);         //ESP32 web
+#include "SPIFFS.h"           // ESP32 SPIFFS for store config
+#define LittleFS SPIFFS       // alias LittleFS to SPIFFS
+WebServer server(80);         // ESP32 web
 #else
 #include <ESP8266WiFi.h>      // WIFI for ESP8266
 #include <ESP8266mDNS.h>      // mDNS for ESP8266
 #include <ESP8266WebServer.h> // webServer for ESP8266
 ESP8266WebServer server(80);  // ESP8266 web
-#endif
 #include <LittleFS.h>         // SPIFFS replacement
+#endif
 #include <ArduinoJson.h>      // json to process MQTT: ArduinoJson 6.11.4
 #include <PubSubClient.h>     // MQTT: PubSubClient 2.7.0
 #include <DNSServer.h>        // DNS for captive portal

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -20,7 +20,7 @@
 #include <WiFiUdp.h>
 #include <ESPmDNS.h>          // mDNS for ESP32
 #include <WebServer.h>        // webServer for ESP32
-#include "SPIFFS.h"           // ESP32 SPIFFS for store config
+#include "LittleFS.h"           // ESP32 SPIFFS for store config
 WebServer server(80);         //ESP32 web
 #else
 #include <ESP8266WiFi.h>      // WIFI for ESP8266
@@ -28,6 +28,7 @@ WebServer server(80);         //ESP32 web
 #include <ESP8266WebServer.h> // webServer for ESP8266
 ESP8266WebServer server(80);  // ESP8266 web
 #endif
+#include <LittleFS.h>         // SPIFFS replacement
 #include <ArduinoJson.h>      // json to process MQTT: ArduinoJson 6.11.4
 #include <PubSubClient.h>     // MQTT: PubSubClient 2.7.0
 #include <DNSServer.h>        // DNS for captive portal
@@ -83,15 +84,15 @@ void setup() {
   Serial.begin(115200);
   // Serial.println(F("Starting Mitsubishi2MQTT"));
   // Mount SPIFFS filesystem
-  if (SPIFFS.begin())
+  if (LittleFS.begin())
   {
     // Serial.println(F("Mounted file system"));
   }
   else
   {
     // Serial.println(F("Failed to mount FS -> formating"));
-    SPIFFS.format();
-    // if (SPIFFS.begin())
+    LittleFS.format();
+    // if (LittleFS.begin())
       // Serial.println(F("Mounted file system after formating"));
   }
   //set led pin as output
@@ -114,8 +115,8 @@ void setup() {
   loadOthers();
   loadUnit();
   if (initWifi()) {
-    if (SPIFFS.exists(console_file)) {
-      SPIFFS.remove(console_file);
+    if (LittleFS.exists(console_file)) {
+      LittleFS.remove(console_file);
     }
     //write_log("Starting Mitsubishi2MQTT");
     //Web interface
@@ -194,11 +195,11 @@ void setup() {
 bool loadWifi() {
   ap_ssid = "";
   ap_pwd  = "";
-  if (!SPIFFS.exists(wifi_conf)) {
+  if (!LittleFS.exists(wifi_conf)) {
     // Serial.println(F("Wifi config file not exist!"));
     return false;
   }
-  File configFile = SPIFFS.open(wifi_conf, "r");
+  File configFile = LittleFS.open(wifi_conf, "r");
   if (!configFile) {
     // Serial.println(F("Failed to open wifi config file"));
     return false;
@@ -241,7 +242,7 @@ void saveMqtt(String mqttFn, String mqttHost, String mqttPort, String mqttUser,
   doc["mqtt_user"] = mqttUser;
   doc["mqtt_pwd"] = mqttPwd;
   doc["mqtt_topic"] = mqttTopic;
-  File configFile = SPIFFS.open(mqtt_conf, "w");
+  File configFile = LittleFS.open(mqtt_conf, "w");
   if (!configFile) {
     // Serial.println(F("Failed to open config file for writing"));
   }
@@ -271,7 +272,7 @@ void saveUnit(String tempUnit, String supportMode, String loginPassword, String 
   // if login password is empty, we use empty
   if (loginPassword == '\0') loginPassword = "";
   doc["login_password"]   = loginPassword;
-  File configFile = SPIFFS.open(unit_conf, "w");
+  File configFile = LittleFS.open(unit_conf, "w");
   if (!configFile) {
     // Serial.println(F("Failed to open config file for writing"));
   }
@@ -287,7 +288,7 @@ void saveWifi(String apSsid, String apPwd, String hostName, String otaPwd) {
   doc["ap_pwd"] = apPwd;
   doc["hostname"] = hostName;
   doc["ota_pwd"] = otaPwd;
-  File configFile = SPIFFS.open(wifi_conf, "w");
+  File configFile = LittleFS.open(wifi_conf, "w");
   if (!configFile) {
     // Serial.println(F("Failed to open wifi file for writing"));
   }
@@ -303,7 +304,7 @@ void saveOthers(String haa, String haat, String debug) {
   doc["haa"] = haa;
   doc["haat"] = haat;
   doc["debug"] = debug;
-  File configFile = SPIFFS.open(others_conf, "w");
+  File configFile = LittleFS.open(others_conf, "w");
   if (!configFile) {
     // Serial.println(F("Failed to open wifi file for writing"));
   }
@@ -357,12 +358,12 @@ void initOTA() {
 }
 
 bool loadMqtt() {
-  if (!SPIFFS.exists(mqtt_conf)) {
+  if (!LittleFS.exists(mqtt_conf)) {
     Serial.println(F("MQTT config file not exist!"));
     return false;
   }
   //write_log("Loading MQTT configuration");
-  File configFile = SPIFFS.open(mqtt_conf, "r");
+  File configFile = LittleFS.open(mqtt_conf, "r");
   if (!configFile) {
     //write_log("Failed to open MQTT config file");
     return false;
@@ -400,11 +401,11 @@ bool loadMqtt() {
 }
 
 bool loadUnit() {
-  if (!SPIFFS.exists(unit_conf)) {
+  if (!LittleFS.exists(unit_conf)) {
     // Serial.println(F("Unit config file not exist!"));
     return false;
   }
-  File configFile = SPIFFS.open(unit_conf, "r");
+  File configFile = LittleFS.open(unit_conf, "r");
   if (!configFile) {
     return false;
   }
@@ -439,11 +440,11 @@ bool loadUnit() {
 
 
 bool loadOthers() {
-  if (!SPIFFS.exists(others_conf)) {
+  if (!LittleFS.exists(others_conf)) {
     // Serial.println(F("Others config file not exist!"));
     return false;
   }
-  File configFile = SPIFFS.open(others_conf, "r");
+  File configFile = LittleFS.open(others_conf, "r");
   if (!configFile) {
     return false;
   }
@@ -622,7 +623,7 @@ void handleSetup() {
     pageReset.replace("_TXT_M_RESET_",FPSTR(txt_m_reset));
     pageReset.replace("_SSID_",ssid);
     sendWrappedHTML(pageReset);
-    SPIFFS.format();
+    LittleFS.format();
     delay(500);
 #ifdef ESP32
     ESP.restart();
@@ -1155,7 +1156,7 @@ void handleUploadLoop()
 }
 
 void write_log(String log) {
-  File logFile = SPIFFS.open(console_file, "a");
+  File logFile = LittleFS.open(console_file, "a");
   logFile.println(log);
   logFile.close();
 }


### PR DESCRIPTION
NOTE: while this PR compiles with the OOTB boards supported, there doesn't seem to be a LittleFS port for ESP32 yet, see https://github.com/espressif/arduino-esp32/issues/3765