### PR TITLE
Issue #67 - Auto restart on WiFi drop

### DIFF
--- a/src/mitsubishi2mqtt/config.h
+++ b/src/mitsubishi2mqtt/config.h
@@ -40,6 +40,9 @@ const PROGMEM  uint8_t redLedPin = 0;
 
 // Define global variables for network
 const PROGMEM char* hostnamePrefix = "HVAC_";
+const PROGMEM uint32_t WIFI_RETRY_INTERVAL_MS = 300000;
+int wifi_timeout;
+bool wifi_config_exists;
 String hostname = "";
 String ap_ssid;
 String ap_pwd;


### PR DESCRIPTION
restarts the board after timeout when WiFi dropped or in captive ap mode. Changed password in AP mode to match login_password