### PR TITLE
Fix MQTT state bouncing on commands, add compressorFrequency, bug fixes

### DIFF
--- a/src/mitsubishi2mqtt/config.h
+++ b/src/mitsubishi2mqtt/config.h
@@ -92,7 +92,7 @@ uint8_t max_temp                    = 31; // Maximum temperature, check value fr
 String temp_step                   = "1"; // Temperature setting step, check value from heatpump remote control
 
 // sketch settings
-const PROGMEM uint32_t SEND_ROOM_TEMP_INTERVAL_MS = 30000; // 30 seconds
+const PROGMEM uint32_t SEND_ROOM_TEMP_INTERVAL_MS = 45000; // 45 seconds (anything less may cause bouncing)
 const PROGMEM uint32_t MQTT_RETRY_INTERVAL_MS = 1000; // 1 seconds
 const PROGMEM uint32_t HP_RETRY_INTERVAL_MS = 1000; // 1 seconds
 const PROGMEM uint32_t HP_MAX_RETRIES = 5;


### PR DESCRIPTION
- Fix bouncing MQTT states on command by keeping track locally of the state

- Add resilience when sending multiple commands in rapid succession by ignoring
  status callbacks until SEND_ROOM_TEMP_INTERVAL_MS after the last command

- Increase default SEND_ROOM_TEMP_INTERVAL_MS to 45 seconds

- Add compressorFrequency to MQTT state

- Fix temperature setting sanity check to be Fahrenheit-friendly

- Remove vestigial JSON document generation incorrectly left behind after dummy packets were centralized

Resolves #94