### PR TITLE
Set 'temperature_unit' in HomeAssistant config

### DIFF
--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1516,6 +1516,7 @@ void haConfig() {
   haConfig["max_temp"]                      = convertCelsiusToLocalUnit(max_temp, useFahrenheit);
   haConfig["temp_step"]                     = temp_step;
   haConfig["pow_cmd_t"]                     = ha_power_set_topic;
+  haConfig["temperature_unit"]              = useFahrenheit ? "F" : "C";
 
   JsonArray haConfigFan_modes = haConfig.createNestedArray("fan_modes");
   haConfigFan_modes.add("AUTO");


### PR DESCRIPTION
Set the 'temperature_unit' in the HomeAssistant discovery config. This lets HomeAssistant know what units this climate device is operating with (so it can do temperature conversions properly on the HomeAssistant side).