### PR TITLE
Fix pointer to Swicago Libs

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -6,7 +6,6 @@ src_dir = src/mitsubishi2mqtt
 
 [common]
 lib_deps_ext =
-    HeatPump @1.0.0
     ArduinoJson @6.15.2
     PubSubClient @2.8
     
@@ -14,6 +13,8 @@ lib_deps_ext =
 platform = espressif8266
 board = d1_mini
 framework = arduino
-lib_deps = ${common.lib_deps_ext}
+lib_deps = 
+    ${common.lib_deps_ext} 
+    https://github.com/SwiCago/HeatPump
 monitor_speed = 115200
 upload_speed = 460800


### PR DESCRIPTION
Fix pointer to Swicago Libs as https://libraries.io/platformio/HeatPump is not updated to use the Github link instead.