### PR TITLE
Added support for switching the unit on with last used values via MQTT

### DIFF
--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1367,6 +1367,9 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
     if (modeUpper == "OFF") {
       hp.setPowerSetting("OFF");
       hp.update();
+    } else if (modeUpper == "ON") {
+      hp.setPowerSetting("ON");
+      hp.update();
     }
   }
   else if (strcmp(topic, ha_mode_set_topic.c_str()) == 0) {


### PR DESCRIPTION
Added support for switching the unit on with last used values (mode, temp, etc.) via MQTT "ON" command to power/set topic.

Proposed fix for https://github.com/gysmo38/mitsubishi2MQTT/issues/142