### PR TITLE
Fix corrupted "mode" values, enforce auth checks.

### DIFF
--- a/src/mitsubishi2mqtt/config.h
+++ b/src/mitsubishi2mqtt/config.h
@@ -41,7 +41,7 @@ const PROGMEM  uint8_t redLedPin = 0;
 // Define global variables for network
 const PROGMEM char* hostnamePrefix = "HVAC_";
 const PROGMEM uint32_t WIFI_RETRY_INTERVAL_MS = 300000;
-int wifi_timeout;
+unsigned long wifi_timeout;
 bool wifi_config_exists;
 String hostname = "";
 String ap_ssid;

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -260,7 +260,6 @@ void saveMqtt(String mqttFn, String mqttHost, String mqttPort, String mqttUser,
   if (!configFile) {
     // Serial.println(F("Failed to open config file for writing"));
   }
-  serializeJson(doc, Serial);
   serializeJson(doc, configFile);
   configFile.close();
 }
@@ -269,28 +268,27 @@ void saveUnit(String tempUnit, String supportMode, String loginPassword, String 
   const size_t capacity = JSON_OBJECT_SIZE(6) + 200;
   DynamicJsonDocument doc(capacity);
   // if temp unit is empty, we use default celcius
-  if (tempUnit == '\0') tempUnit = "cel";
+  if (tempUnit.length() == 0) tempUnit = "cel";
   doc["unit_tempUnit"]   = tempUnit;
   // if minTemp is empty, we use default 16
-  if (minTemp == '\0') minTemp = 16;
+  if (minTemp.length() == 0) minTemp = 16;
   doc["min_temp"]   = minTemp;
   // if maxTemp is empty, we use default 31
-  if (maxTemp == '\0') maxTemp = 31;
+  if (maxTemp.length() == 0) maxTemp = 31;
   doc["max_temp"]   = maxTemp;
   // if tempStep is empty, we use default 1
-  if (tempStep == '\0') tempStep = 1;
+  if (tempStep.length() == 0) tempStep = 1;
   doc["temp_step"] = tempStep;
   // if support mode is empty, we use default all mode
-  if (supportMode == '\0') supportMode = "all";
+  if (supportMode.length() == 0) supportMode = "all";
   doc["support_mode"]   = supportMode;
   // if login password is empty, we use empty
-  if (loginPassword == '\0') loginPassword = "";
+  if (loginPassword.length() == 0) loginPassword = "";
   doc["login_password"]   = loginPassword;
   File configFile = SPIFFS.open(unit_conf, "w");
   if (!configFile) {
     // Serial.println(F("Failed to open config file for writing"));
   }
-  serializeJson(doc, Serial);
   serializeJson(doc, configFile);
   configFile.close();
 }
@@ -306,7 +304,6 @@ void saveWifi(String apSsid, String apPwd, String hostName, String otaPwd) {
   if (!configFile) {
     // Serial.println(F("Failed to open wifi file for writing"));
   }
-  serializeJson(doc, Serial);
   serializeJson(doc, configFile);
   delay(10);
   configFile.close();


### PR DESCRIPTION
A couple of bug fixes and some compiler warnings/errors:
- MQTT status messages contained a corrupted `"mode"` values. The culprit was `rootInfo["mode"] = hpmode.c_str();`, the fix is just to remove the `c_str()` call but I also kept some of the refactoring/cleanup changes I needed to discover it.
```
2021-11-28 21:04:13 WARNING (MainThread) [homeassistant.components.mqtt] Can't decode payload b'{"temperature":19.5,"fan":"AUTO","vane":"AUTO","wideVane":"|","mode":"\xcd_ @"}' on hvac/hp-basement/state with encoding utf-8 (for <Job HassJobType.Callback <function MqttClimate._subscribe_topics.<locals>.handle_swing_mode_received at 0xffff791eaca0>>)
```
- HTTP request handler functions terminate immediately if `checkLogin()` fails. The unauthorized changes were getting applied even though the HTTP response indicated failure (redirect to login).
- Fixed compilation warnings/errors.