### PR TITLE
Use MAC serial part as unique identifier

### DIFF
--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1686,8 +1686,7 @@ String getTemperatureScale() {
 String getId() {
 #ifdef ESP32
   uint64_t macAddress = ESP.getEfuseMac();
-  uint64_t macAddressTrunc = macAddress << 40;
-  uint32_t chipID = macAddressTrunc >> 40;
+  uint32_t chipID = macAddress >> 24;
 #else
   uint32_t chipID = ESP.getChipId();
 #endif


### PR DESCRIPTION
Fixes #188

Previous implementation used mac vendor part in getId() Tested with ESP-WROOM-32 module from az-delivery