### PR TITLE
Update HASS temp_stat_tpl min-max enforcement

### DIFF
--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1504,10 +1504,10 @@ void haConfig() {
   haConfig["pl_not_avail"]                  = mqtt_payload_unavailable; // MQTT offline message payload
   haConfig["pl_avail"]                      = mqtt_payload_available; // MQTT online message payload
   //Set default value for fix "Could not parse data for HA"
-  String temp_stat_tpl_str                  = F("{% if (value_json is defined and value_json.temperature is defined) %}{% if (value_json.temperature|int > ");
-  temp_stat_tpl_str                        +=(String)convertCelsiusToLocalUnit(min_temp, useFahrenheit) + " and value_json.temperature|int < ";
-  temp_stat_tpl_str                        +=(String)convertCelsiusToLocalUnit(max_temp, useFahrenheit) + ") %}{{ value_json.temperature }}";
-  temp_stat_tpl_str                        +="{% elif (value_json.temperature|int < " + (String)convertCelsiusToLocalUnit(min_temp, useFahrenheit) + ") %}" + (String)convertCelsiusToLocalUnit(min_temp, useFahrenheit) + "{% elif (value_json.temperature|int > " + (String)convertCelsiusToLocalUnit(max_temp, useFahrenheit) + ") %}" + (String)convertCelsiusToLocalUnit(max_temp, useFahrenheit) +  "{% endif %}{% else %}" + (String)convertCelsiusToLocalUnit(22, useFahrenheit) + "{% endif %}";
+  String temp_stat_tpl_str                  = F("{% if (value_json is defined and value_json.temperature is defined) %}{{ value_json.temperature|float");
+  temp_stat_tpl_str                        +="|min(" + (String)convertCelsiusToLocalUnit(min_temp, useFahrenheit) + ")";
+  temp_stat_tpl_str                        +="|max(" + (String)convertCelsiusToLocalUnit(max_temp, useFahrenheit) + ")";
+  temp_stat_tpl_str                        +=" }}{% else %}" + (String)convertCelsiusToLocalUnit(22, useFahrenheit) + "{% endif %}";
   haConfig["temp_stat_tpl"]                 = temp_stat_tpl_str;
   haConfig["curr_temp_t"]                   = ha_state_topic;
   String curr_temp_tpl_str                  = F("{{ value_json.roomTemperature if (value_json is defined and value_json.roomTemperature is defined and value_json.roomTemperature|int > ");


### PR DESCRIPTION
Allow values including min and max values instead of just greater and smaller then. Replaces ifelse by Jinja embedded min and max functions.

Fixes HASS ERROR "Could not parse temperature from" if set temp equals min or max temp.