### PR TITLE
Safer remote temperature sensing

### DIFF
--- a/src/mitsubishi2mqtt/config.h
+++ b/src/mitsubishi2mqtt/config.h
@@ -16,7 +16,7 @@
 
 /*#define MY_LANGUAGE zh-CN // define your language*/
 
-const PROGMEM char* m2mqtt_version = "2022.12.0";
+const PROGMEM char* m2mqtt_version = "2023.1.0";
 
 //Define global variables for files
 #ifdef ESP32

--- a/src/mitsubishi2mqtt/config.h
+++ b/src/mitsubishi2mqtt/config.h
@@ -102,6 +102,7 @@ String temp_step                   = "1"; // Temperature setting step, check val
 
 // sketch settings
 const PROGMEM uint32_t SEND_ROOM_TEMP_INTERVAL_MS = 30000; // 45 seconds (anything less may cause bouncing)
+const PROGMEM uint32_t CHECK_REMOTE_TEMP_INTERVAL_MS = 300000; //5 minutes
 const PROGMEM uint32_t MQTT_RETRY_INTERVAL_MS = 1000; // 1 second
 const PROGMEM uint32_t HP_RETRY_INTERVAL_MS = 1000; // 1 second
 const PROGMEM uint32_t HP_MAX_RETRIES = 10; // Double the interval between retries up to this many times, then keep retrying forever at that maximum interval.

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -564,7 +564,7 @@ void handleNotFound() {
 
 void handleSaveWifi() {
   if (!checkLogin()) return;
-  
+
   // Serial.println(F("Saving wifi config"));
   if (server.method() == HTTP_POST) {
     saveWifi(server.arg("ssid"), server.arg("psk"), server.arg("hn"), server.arg("otapwd"));
@@ -578,7 +578,7 @@ void handleSaveWifi() {
 
 void handleReboot() {
   if (!checkLogin()) return;
-  
+
   String initRebootPage = FPSTR(html_init_reboot);
   initRebootPage.replace("_TXT_INIT_REBOOT_",FPSTR(txt_init_reboot));
   sendWrappedHTML(initRebootPage);
@@ -588,7 +588,7 @@ void handleReboot() {
 
 void handleRoot() {
   if (!checkLogin()) return;
-  
+
   if (server.hasArg("REBOOT")) {
     String rebootPage =  FPSTR(html_page_reboot);
     String countDown = FPSTR(count_down_script);
@@ -672,7 +672,7 @@ void rebootAndSendPage() {
 
 void handleOthers() {
   if (!checkLogin()) return;
-  
+
   if (server.method() == HTTP_POST) {
     saveOthers(server.arg("HAA"), server.arg("haat"), server.arg("DebugPckts"),server.arg("DebugLogs"));
     rebootAndSendPage();
@@ -714,7 +714,7 @@ void handleOthers() {
 
 void handleMqtt() {
   if (!checkLogin()) return;
-  
+
   if (server.method() == HTTP_POST) {
     saveMqtt(server.arg("fn"), server.arg("mh"), server.arg("ml"), server.arg("mu"), server.arg("mp"), server.arg("mt"));
     rebootAndSendPage();
@@ -742,7 +742,7 @@ void handleMqtt() {
 
 void handleUnit() {
   if (!checkLogin()) return;
-  
+
   if (server.method() == HTTP_POST) {
     saveUnit(server.arg("tu"), server.arg("md"), server.arg("lpw"), (String)convertLocalUnitToCelsius(server.arg("min_temp").toInt(), useFahrenheit), (String)convertLocalUnitToCelsius(server.arg("max_temp").toInt(), useFahrenheit), server.arg("temp_step"));
     rebootAndSendPage();
@@ -778,7 +778,7 @@ void handleUnit() {
 
 void handleWifi() {
   if (!checkLogin()) return;
-  
+
   if (server.method() == HTTP_POST) {
     saveWifi(server.arg("ssid"), server.arg("psk"), server.arg("hn"), server.arg("otapwd"));
     rebootAndSendPage();
@@ -813,7 +813,7 @@ void handleWifi() {
 
 void handleStatus() {
   if (!checkLogin()) return;
-  
+
   String statusPage =  FPSTR(html_page_status);
   statusPage.replace("_TXT_BACK_", FPSTR(txt_back));
   statusPage.replace("_TXT_STATUS_TITLE_", FPSTR(txt_status_title));
@@ -846,7 +846,7 @@ void handleStatus() {
 
 void handleControl() {
   if (!checkLogin()) return;
-  
+
   //not connected to hp, redirect to status page
   if (!hp.isConnected()) {
     server.sendHeader("Location", "/status");
@@ -1053,7 +1053,7 @@ void handleLogin() {
 
 void handleUpgrade() {
   if (!checkLogin()) return;
-  
+
   uploaderror = 0;
   String upgradePage = FPSTR(html_page_upgrade);
   upgradePage.replace("_TXT_B_UPGRADE_",FPSTR(txt_upgrade));
@@ -1119,7 +1119,7 @@ void handleUploadDone() {
 
 void handleUploadLoop() {
   if (!checkLogin()) return;
-  
+
   // Based on ESP8266HTTPUpdateServer.cpp uses ESP8266WebServer Parsing.cpp and Cores Updater.cpp (Update)
   //char log[200];
   if (uploaderror) {
@@ -1248,7 +1248,7 @@ void readHeatPumpSettings() {
 
 void hpSettingsChanged() {
   // send room temp, operating info and all information
-  readHeatPumpSettings();  
+  readHeatPumpSettings();
 
   String mqttOutput;
   serializeJson(rootInfo, mqttOutput);
@@ -1263,8 +1263,8 @@ void hpSettingsChanged() {
 String hpGetMode(heatpumpSettings hpSettings) {
   // Map the heat pump state to one of HA's HVAC_MODE_* values.
   // https://github.com/home-assistant/core/blob/master/homeassistant/components/climate/const.py#L3-L23
-  
-  String hppower = String(hpSettings.power); 
+
+  String hppower = String(hpSettings.power);
   if (hppower.equalsIgnoreCase("off")){
     return "off";
   }
@@ -1280,7 +1280,7 @@ String hpGetMode(heatpumpSettings hpSettings) {
 String hpGetAction(heatpumpStatus hpStatus, heatpumpSettings hpSettings) {
   // Map heat pump state to one of HA's CURRENT_HVAC_* values.
   // https://github.com/home-assistant/core/blob/master/homeassistant/components/climate/const.py#L80-L86
-  
+
   String hppower = String(hpSettings.power);
   if (hppower.equalsIgnoreCase("off")) {
     return "off";
@@ -1527,7 +1527,7 @@ void haConfig() {
   haConfig["mode_stat_tpl"]                 = F("{{ value_json.mode if (value_json is defined and value_json.mode is defined and value_json.mode|length) else 'off' }}"); //Set default value for fix "Could not parse data for HA"
   haConfig["temp_cmd_t"]                    = ha_temp_set_topic;
   haConfig["temp_stat_t"]                   = ha_state_topic;
-  haConfig["avty_t"]                        = ha_availability_topic; // MQTT last will (status) messages topic 
+  haConfig["avty_t"]                        = ha_availability_topic; // MQTT last will (status) messages topic
   haConfig["pl_not_avail"]                  = mqtt_payload_unavailable; // MQTT offline message payload
   haConfig["pl_avail"]                      = mqtt_payload_available; // MQTT online message payload
   //Set default value for fix "Could not parse data for HA"
@@ -1757,14 +1757,14 @@ bool checkLogin() {
 void loop() {
   server.handleClient();
   ArduinoOTA.handle();
-  
+
   //reset board to attempt to connect to wifi again if in ap mode or wifi dropped out and time limit passed
   if (WiFi.getMode() == WIFI_STA and WiFi.status() == WL_CONNECTED) {
 	  wifi_timeout = millis() + WIFI_RETRY_INTERVAL_MS;
   } else if (wifi_config_exists and millis() > wifi_timeout) {
 	  ESP.restart();
   }
-  
+
   if (!captive) {
     // Sync HVAC UNIT
     if (!hp.isConnected()) {

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1302,6 +1302,8 @@ String hpGetAction(heatpumpStatus hpStatus, heatpumpSettings hpSettings) {
 
 void hpStatusChanged(heatpumpStatus currentStatus) {
   if (millis() - lastTempSend > SEND_ROOM_TEMP_INTERVAL_MS) { // only send the temperature every SEND_ROOM_TEMP_INTERVAL_MS (millis rollover tolerant)
+    hpCheckRemoteTemp(); // if the remote temperature feed from mqtt is stale, disable it and revert to the internal thermometer.
+
     // send room temp, operating info and all information
     heatpumpSettings currentSettings = hp.getSettings();
 
@@ -1813,7 +1815,6 @@ void loop() {
 		//MQTT connected send status
 		else {
 		  hpStatusChanged(hp.getStatus());
-		  hpCheckRemoteTemp();
 		  mqtt_client.loop();
 		}
 	}

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -106,16 +106,16 @@ void setup() {
   //Define hostname
   hostname += hostnamePrefix;
   hostname += getId();
+  setDefaults();
+  wifi_config_exists = loadWifi();
+  loadOthers();
+  loadUnit();
   mqtt_client_id = hostname;
 #ifdef ESP32
   WiFi.setHostname(hostname.c_str());
 #else
   WiFi.hostname(hostname.c_str());
 #endif
-  setDefaults();
-  wifi_config_exists = loadWifi();
-  loadOthers();
-  loadUnit();
   if (initWifi()) {
     if (SPIFFS.exists(console_file)) {
       SPIFFS.remove(console_file);


### PR DESCRIPTION
There are a handful of changes in here, but the biggest one is updating the code which handles the remote temperature setting to disable itself if the remote temperature sensor stops transmitting. This is to prevent a "runaway" state, where your heat pump would just be constantly heating/cooling forever, since it wouldn't see any change in the room temperature. 

Joint effort between @brackw and myself. 

Resolves https://github.com/gysmo38/mitsubishi2MQTT/issues/167