### PR TITLE
Esp32 serial logging

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -1,0 +1,41 @@
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build WEMOS_D1_Mini
+        run: |
+          pio run -e WEMOS_D1_Mini
+          mv .pio/build/WEMOS_D1_Mini/firmware.bin mitsubishi2MQTT_WEMOS_D1_Mini.bin
+
+      - name: Build esp32dev
+        run: |
+          pio run -e esp32dev
+          mv .pio/build/esp32dev/firmware.bin mitsubishi2MQTT_esp32dev.bin
+
+      - name: Upload esp32dev artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: mitsubishi2MQTT_esp32dev.bin
+          path: mitsubishi2MQTT_esp32dev.bin
+
+      - name: Upload WEMOS_D1_Mini artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: mitsubishi2MQTT_WEMOS_D1_Mini.bin
+          path: mitsubishi2MQTT_WEMOS_D1_Mini.bin

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,3 +25,5 @@ board = esp32dev
 framework = arduino
 lib_deps = 
 	${common.lib_deps_ext}
+build_flags =
+    -D CORE_DEBUG_LEVEL=0


### PR DESCRIPTION
I was testing a new build of this project on a generic esp32 board and to be sure I had the uart connected correctly on my CN105 cable I jumpered it to a separate usb-serial converter. This is what I saw on the console after clicking around the webui:
```
I%]\xf8M0\x81\t4\xa2\xa74\xa2\xa2O\xc9F\xf4\xf1z%\x97%\Q\xfc\x8eR\xf5\xaf\xbe\xe6x\xf8xx\x80\x80xxx\xfcZ0\xca\xa8x\xf8xx\x80\x80xxx\xfcZ0\xca\xa8x\xf8xx\x80\x80xxx\xfcZ0\xca\xa8x\xf8xx\x80\x80xxx\xfcZ0\xca\xa8x\xf8xx\x80\x80xxx\xfcZ0\xca\xa8x\xf8xx\x80\x80xxx\xfcZ0\xca\xa8x\xf8xx\x80\x80xxx\xfcZ0\xca\xa8x\xf8xx\x80\x80xxx\xfcZ0\xca\xa8x\xf8xx\x80\x80xxx\xfcZ0\xca\xa8x\xf8xx\x80\x80xxx\xfcZ0\xca\xa8[546035][E][WebServer.cpp:649] _handleRequest(): request handler not found
[549335][E][WebServer.cpp:649] _handleRequest(): request handler not found
[552414][E][WebServer.cpp:649] _handleRequest(): request handler not found
```

I saw Tasmota actually had the same issue a while back, it's an esp32 thing: https://github.com/arendst/Tasmota/commit/761332d286802c6975c1b9108e6c00aa92855230

I've copied their fix here.