### PR TITLE
split debug messages by direction and message type

### DIFF
--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1341,6 +1341,7 @@ void hpCheckRemoteTemp(){
 void hpPacketDebug(byte* packet, unsigned int length, const char* packetDirection) {
   if (_debugModePckts) {
     String message;
+    String topic = ha_debug_pckts_topic + "/" + packetDirection + "/" + String(packet[5], HEX); // packet 5 is message type
     for (unsigned int idx = 0; idx < length; idx++) {
       if (packet[idx] < 16) {
         message += "0"; // pad single hex digits with a 0
@@ -1354,7 +1355,7 @@ void hpPacketDebug(byte* packet, unsigned int length, const char* packetDirectio
     root[packetDirection] = message;
     String mqttOutput;
     serializeJson(root, mqttOutput);
-    if (!mqtt_client.publish(ha_debug_pckts_topic.c_str(), mqttOutput.c_str())) {
+    if (!mqtt_client.publish(topic.c_str(), mqttOutput.c_str())) {
       mqtt_client.publish(ha_debug_logs_topic.c_str(), (char*)("Failed to publish to heatpump/debug topic"));
     }
   }


### PR DESCRIPTION
I don't know if you actually want to merge this or not. It makes the debug messages much easier to follow (by splitting them up into separate topics according to what type of packet they are), at the cost of being much more verbose.

With this, you can actually kind of see what's changing over time, by comparing consecutive messages, which will be mostly the same. 