### PR TITLE
Added reboot logic to esp32 if fails to connect

### DIFF
--- a/src/mitsubishi2mqtt/config.h
+++ b/src/mitsubishi2mqtt/config.h
@@ -41,6 +41,7 @@ const PROGMEM  uint8_t redLedPin = 0;
 // Define global variables for network
 const PROGMEM char* hostnamePrefix = "HVAC_";
 const PROGMEM uint32_t WIFI_RETRY_INTERVAL_MS = 300000;
+const int CONNECTION_TIMEOUT = 10;
 unsigned long wifi_timeout;
 bool wifi_config_exists;
 String hostname = "";

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1655,6 +1655,8 @@ bool connectWifi() {
   WiFi.begin(ap_ssid.c_str(), ap_pwd.c_str());
   // Serial.println("Connecting to " + ap_ssid);
   wifi_timeout = millis() + 30000;
+  int timeout_counter = 0;
+
   while (WiFi.status() != WL_CONNECTED && millis() < wifi_timeout) {
     Serial.write('.');
     //Serial.print(WiFi.status());
@@ -1663,6 +1665,13 @@ bool connectWifi() {
     delay(250);
     digitalWrite(blueLedPin, HIGH);
     delay(250);
+    //reboot ESP32 if fails to connect after retries
+#ifdef ESP32
+    timeout_counter++;
+    if(timeout_counter >= CONNECTION_TIMEOUT * 5){
+      ESP.restart();
+    }
+#endif
   }
   if (WiFi.status() != WL_CONNECTED) {
     // Serial.println(F("Failed to connect to wifi"));


### PR DESCRIPTION
Currently, ESP32 mostly fails to connect to WIFI on the first boot. I added a reboot logic if ESP32 fails to connect after n retries. 