### PR TITLE
Nightly builds

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -1,4 +1,7 @@
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: "0 2 * * *"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ How to use:
  - Step 6: (optional): Set MQTT information for use with Home Assistant
  - Step 7: (optional): Set Login password to prevent unwanted access in SETUP->ADVANCE->Login Password
 
-Nightly builds are available for select platforms via GitHub Actions. Go to [the platformio action](https://github.com/gysmo38/mitsubishi2MQTT/actions/workflows/platformio.yml), select the latest build, then check the **Artifacts** section. 
+Nightly builds are available for select platforms via GitHub Actions. Go to [the platformio workflow](https://github.com/gysmo38/mitsubishi2MQTT/actions/workflows/platformio.yml), select the latest build, then check the **Artifacts** section. 
 
 ***
 For nodered fans MQTT topic use cases

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ How to use:
  - Step 6: (optional): Set MQTT information for use with Home Assistant
  - Step 7: (optional): Set Login password to prevent unwanted access in SETUP->ADVANCE->Login Password
 
+Nightly builds are available for select platforms via GitHub Actions. Go to [the platformio action](https://github.com/gysmo38/mitsubishi2MQTT/actions/workflows/platformio.yml), select the latest build, then check the **Artifacts** section. 
+
 ***
 For nodered fans MQTT topic use cases
 - topic/power/set OFF


### PR DESCRIPTION
I want to update my heat pumps to use https://github.com/SwiCago/HeatPump/pull/199 . If mitsubishi2MQTT had a nightly release, I could just download the bin instead of having to spend time compiling.

Additionally, I find nightly builds to be a best practice in order to catch breaking changes in dependencies. When your last release was 5+ months ago and something breaks, it can be much harder to figure out the root cause.