### PR TITLE
MQTT device name equal to entity name error fix

### DIFF
--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1518,7 +1518,7 @@ void haConfig() {
   const size_t capacity = JSON_ARRAY_SIZE(5) + 2 * JSON_ARRAY_SIZE(6) + JSON_ARRAY_SIZE(7) + JSON_OBJECT_SIZE(24) + 2048;
   DynamicJsonDocument haConfig(capacity);
 
-  haConfig["name"]                          = mqtt_fn;
+  haConfig["name"]                          = nullptr;
   haConfig["unique_id"]                     = getId();
 
   JsonArray haConfigModes = haConfig.createNestedArray("modes");


### PR DESCRIPTION
Starting from Home Assistant version 2023.08, you no longer need to specify entity names when they match the device name. This update resolves the warning in the Home Assistant logs that states: 

`MQTT device name is equal to entity name in your config.`