### PR TITLE
Update platformio.yml

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -32,13 +32,13 @@ jobs:
           mv .pio/build/esp32dev/firmware.bin mitsubishi2MQTT_esp32dev.bin
 
       - name: Upload esp32dev artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mitsubishi2MQTT_esp32dev.bin
           path: mitsubishi2MQTT_esp32dev.bin
 
       - name: Upload WEMOS_D1_Mini artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mitsubishi2MQTT_WEMOS_D1_Mini.bin
           path: mitsubishi2MQTT_WEMOS_D1_Mini.bin


### PR DESCRIPTION
actions/upload-artifact@v2 is deprecated and throws a warning on builds: https://github.com/gysmo38/mitsubishi2MQTT/actions/runs/5768277456

![Screenshot 2023-08-05 102551](https://github.com/gysmo38/mitsubishi2MQTT/assets/1984514/f9a50356-9400-4698-954a-9a2a87def8fa)
