### PR TITLE
Fix #229: Match Arduino flash layout

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -1,5 +1,6 @@
 on:
   push:
+  pull_request:
   schedule:
     - cron: "0 2 * * *"
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,7 @@ board = d1_mini
 framework = arduino
 monitor_speed = 115200
 upload_speed = 460800
+board_build.ldscript = eagle.flash.4m2m.ld
 
 [env:ESP32DEV]
 platform = espressif32

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,7 @@ board = d1_mini
 framework = arduino
 monitor_speed = 115200
 upload_speed = 460800
+; Aligns flash layout to default Arduino IDE settings
 board_build.ldscript = eagle.flash.4m2m.ld
 
 [env:ESP32DEV]


### PR DESCRIPTION
According to the docs this should align the flash layout to the Arduino IDE defaults:

- https://github.com/esp8266/Arduino/blob/master/tools/sdk/ld/eagle.flash.4m2m.ld
- https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs

I tested this and verified that upgrading a Wemos D1 Mini via the web UI works great under both possible conditions:

- When the existing firmware was uploaded using default Arduino IDE settings
- When the existing firmware was uploaded from platform.io via the web UI