### PR TITLE
Expose compressorFrequency to Home Assistant Attributes

### DIFF
--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1641,6 +1641,12 @@ void haConfig() {
   haConfigDevice["mf"]    = "MITSUBISHI ELECTRIC";
   haConfigDevice["configuration_url"]    = "http://"+WiFi.localIP().toString();
   
+  // Additional attributes are in the state
+  // For now, only compressorFrequency
+  haConfig["json_attr_t"]                   = ha_state_topic;
+  haConfig["json_attr_tpl"]                 = F("{{ {'compressorFrequency': value_json.compressorFrequency if (value_json is defined and value_json.compressorFrequency is defined) else '-1' } | tojson }}");
+  
+  
   String mqttOutput;
   serializeJson(haConfig, mqttOutput);
   mqtt_client.beginPublish(ha_config_topic.c_str(), mqttOutput.length(), true);


### PR DESCRIPTION
Home Assistant's HVAC MQTT implementation allows "additional attributes" by passing a json_attribute_topic.

State topic for mitsubishi2mqtt already includes **compressorFrequency** so we just extract it with a **json_attribute_template** (output is a JSON DICT)

This mechanism can probably be used to expose `wideVane` (since HASS only sees `vane`) but I have no clue what vane or wideVane is (my unit is whole home)

![image](https://github.com/gysmo38/mitsubishi2MQTT/assets/1865169/2efc7115-074f-4a4e-bd95-9d9224e0292f)

I implemented this so I could do "defrost" tracking in Home Assistant using the steps here: https://github.com/gysmo38/mitsubishi2MQTT/issues/157#issuecomment-986175308

According to some comments, some Mitsubishi Heat Pumps do not correctly report compressorFrequency...however that seems like an upstream issue with HeatPump library (or just not possible for that model???), rather than an issue that needs to be handled in mitsubishi2mqtt - for now, at least users can see it in HASS and act on it if it's useful, and ignore it if it's not.
