### PR TITLE
Add support for ESP32_S2_MINI, improve device support flexibility, improve debug logging and fix web control interface.

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -25,17 +25,17 @@ jobs:
       - name: Build Generic8266(ESP-01)
         run: |
           pio run -e ESP8266-ESP01
-          mv .pio/build/ESP8266-ESP01/firmware.bin mitsubishi2MQTT_ESP8266-ESP01.bin
+          mv .pio/build/ESP8266-ESP01/mitsubishi2MQTT_ESP8266-ESP01.bin ./
 
       - name: Build WEMOS_D1_Mini
         run: |
           pio run -e WEMOS_D1_Mini
-          mv .pio/build/WEMOS_D1_Mini/firmware.bin mitsubishi2MQTT_WEMOS_D1_Mini.bin
+          mv .pio/build/WEMOS_D1_Mini/mitsubishi2MQTT_WEMOS_D1_Mini.bin ./
 
       - name: Build ESP32DEV
         run: |
           pio run -e ESP32DEV
-          mv .pio/build/ESP32DEV/firmware.bin mitsubishi2MQTT_ESP32DEV.bin
+          mv .pio/build/ESP32DEV/mitsubishi2MQTT_ESP32DEV.bin ./
 
       - name: Upload esp8266 artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -37,6 +37,11 @@ jobs:
           pio run -e ESP32DEV
           mv .pio/build/ESP32DEV/mitsubishi2MQTT_ESP32DEV.bin ./
 
+      - name: Build ESP32-S2-MINI
+        run: |
+          pio run -e ESP32-S2-MINI
+          mv .pio/build/ESP32-S2-MINI/mitsubishi2MQTT_ESP32-S2-MINI.bin ./
+
       - name: Upload esp8266 artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -54,3 +59,9 @@ jobs:
         with:
           name: mitsubishi2MQTT_WEMOS_D1_Mini.bin
           path: mitsubishi2MQTT_WEMOS_D1_Mini.bin
+
+      - name: Upload ESP32-S2-MINI artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: mitsubishi2MQTT_ESP32-S2-MINI.bin
+          path: mitsubishi2MQTT_ESP32-S2-MINI.bin

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,3 +40,11 @@ board = esp32dev
 framework = arduino
 lib_deps = ${env.lib_deps_ext}
 build_flags = -D CORE_DEBUG_LEVEL=0
+
+[env:ESP32-S2-MINI]
+binary_name = mitsubishi2MQTT_ESP32-S2-MINI
+platform = espressif32
+board = lolin_s2_mini
+framework = arduino
+lib_deps = ${env.lib_deps_ext}
+build_flags = -D CORE_DEBUG_LEVEL=0 -DHVAC_UART=0 -DHVAC_UART_RX=16 -DHVAC_UART_TX=18

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,14 +13,18 @@ lib_deps =
 	knolleary/PubSubClient @ ^2.8
 	https://github.com/SwiCago/HeatPump
 
+extra_scripts = pre:prebuild.py
+
 [env:ESP8266-ESP01]
-board = esp01_1m
+binary_name = mitsubishi2MQTT_ESP8266-ESP01
 platform = espressif8266
+board = esp01_1m
 framework = arduino
 monitor_speed = 115200
 board_build.ldscript = eagle.flash.1m64.ld
 
 [env:WEMOS_D1_Mini]
+binary_name = mitsubishi2MQTT_WEMOS_D1_Mini
 platform = espressif8266
 board = d1_mini
 framework = arduino
@@ -30,6 +34,7 @@ upload_speed = 460800
 board_build.ldscript = eagle.flash.4m2m.ld
 
 [env:ESP32DEV]
+binary_name = mitsubishi2MQTT_ESP32DEV
 platform = espressif32
 board = esp32dev
 framework = arduino

--- a/prebuild.py
+++ b/prebuild.py
@@ -1,0 +1,11 @@
+Import("env")
+
+# Set the built firmware binary to the correct name.
+binary_name = env.GetProjectOption("binary_name")
+env.Replace(PROGNAME=binary_name)
+
+# Allow the name of the binary to be reported by the webapp
+env.Append(CPPDEFINES=[
+  ("PIO_BINARY", binary_name)
+])
+

--- a/src/mitsubishi2mqtt/html_pages.h
+++ b/src/mitsubishi2mqtt/html_pages.h
@@ -376,6 +376,7 @@ const char html_page_upgrade[] PROGMEM =
             "<legend><b>&nbsp; _TXT_UPGRADE_TITLE_ &nbsp;</b></legend>"
             "<form method='post' action='upload' enctype='multipart/form-data'>"
                 "<p><span>_TXT_UPGRADE_INFO_</span></p>"
+                "<p><span>_TXT_UPGRADE_BOARD_.bin</span></p>"
                 "<br>"
                 "<input type='file' accept='.bin' name='upload'>"
                 "<br>"

--- a/src/mitsubishi2mqtt/html_pages.h
+++ b/src/mitsubishi2mqtt/html_pages.h
@@ -282,6 +282,25 @@ const char html_page_control[] PROGMEM =
     "var options = document.getElementById('MODE').options;"
     "options[3].disabled = (options[3].value == 'HEAT');"
 "}"
+
+"setInterval(function() {"
+  "checkUpdated();"
+"}, 1000);"
+
+"var lastUpdated = _LAST_UPDATED_;"
+"function checkUpdated() {"
+  "var xhttp = new XMLHttpRequest();"
+  "xhttp.onreadystatechange = function() {"
+    "if (this.readyState == 4 && this.status == 200) {"
+      "var updated = parseInt(this.responseText);"
+      "if (updated != lastUpdated) {"
+        "location.reload();"
+      "}"
+    "}"
+  "};"
+  "xhttp.open('GET', 'updated', true);"
+  "xhttp.send();"
+"}"
 "</script>"
 ;
 

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -45,11 +45,11 @@ ESP8266WebServer server(80);  // ESP8266 web
 #include "html_pages.h"   // code html for pages
 #include "html_metrics.h" // prometheus metrics
 // Languages
+#define QUOTEME(x) QUOTEME_1(x)
+#define QUOTEME_1(x) #x
 #ifndef MY_LANGUAGE
   #include "languages/en-GB.h" // default language English
 #else
-  #define QUOTEME(x) QUOTEME_1(x)
-  #define QUOTEME_1(x) #x
   #define INCLUDE_FILE(x) QUOTEME(languages/x.h)
   #include INCLUDE_FILE(MY_LANGUAGE)
 #endif
@@ -1114,6 +1114,7 @@ void handleUpgrade() {
   upgradePage.replace("_TXT_UPGRADE_TITLE_",FPSTR(txt_upgrade_title));
   upgradePage.replace("_TXT_UPGRADE_INFO_",FPSTR(txt_upgrade_info));
   upgradePage.replace("_TXT_UPGRADE_START_",FPSTR(txt_upgrade_start));
+  upgradePage.replace("_TXT_UPGRADE_BOARD_",QUOTEME(PIO_BINARY));
 
   sendWrappedHTML(upgradePage);
 }

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1002,7 +1002,7 @@ void handleMetrics(){
   heatpumpSettings currentSettings = hp.getSettings();
   heatpumpStatus currentStatus = hp.getStatus();
 
-  String hppower = currentSettings.power == "ON" ? "1" : "0";
+  String hppower = String(currentSettings.power) == "ON" ? "1" : "0";
 
   String hpfan = currentSettings.fan;
   if(hpfan == "AUTO") hpfan = "-1";
@@ -1012,22 +1012,24 @@ void handleMetrics(){
   if(hpvane == "AUTO") hpvane = "-1";
   if(hpvane == "SWING") hpvane = "0";
 
-  String hpwidevane = "-2";
-  if(currentSettings.wideVane == "SWING") hpwidevane = "0";
-  if(currentSettings.wideVane == "<<") hpwidevane = "1";
-  if(currentSettings.wideVane == "<") hpwidevane = "2";
-  if(currentSettings.wideVane == "|") hpwidevane = "3";
-  if(currentSettings.wideVane == ">") hpwidevane = "4";
-  if(currentSettings.wideVane == ">>") hpwidevane = "5";
-  if(currentSettings.wideVane == "<>") hpwidevane = "6";
+  String hpwidevane = currentSettings.wideVane;
+  if(hpwidevane == "SWING") hpwidevane = "0";
+  else if(hpwidevane == "<<") hpwidevane = "1";
+  else if(hpwidevane == "<") hpwidevane = "2";
+  else if(hpwidevane == "|") hpwidevane = "3";
+  else if(hpwidevane == ">") hpwidevane = "4";
+  else if(hpwidevane == ">>") hpwidevane = "5";
+  else if(hpwidevane == "<>") hpwidevane = "6";
+  else hpwidevane = "-2";
 
-  String hpmode = "-2";
-  if(currentSettings.mode == "AUTO") hpmode = "-1";
-  if(currentSettings.mode == "COOL") hpmode = "1";
-  if(currentSettings.mode == "DRY") hpmode = "2";
-  if(currentSettings.mode == "HEAT") hpmode = "3";
-  if(currentSettings.mode == "FAN") hpmode = "4";
-  if(hppower == "0") hpmode = "0";
+  String hpmode = currentSettings.mode;
+  if(hpmode == "AUTO") hpmode = "-1";
+  else if(hpmode == "COOL") hpmode = "1";
+  else if(hpmode == "DRY") hpmode = "2";
+  else if(hpmode == "HEAT") hpmode = "3";
+  else if(hpmode == "FAN") hpmode = "4";
+  else if(hppower == "0") hpmode = "0";
+  else hpmode = "-2";
 
   metrics.replace("_UNIT_NAME_", hostname);
   metrics.replace("_VERSION_", m2mqtt_version);

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -58,6 +58,13 @@ ESP8266WebServer server(80);  // ESP8266 web
 #ifndef HVAC_UART
 #define HVAC_UART 0
 #endif
+#ifndef HVAC_UART_TX
+#define HVAC_UART_TX -1
+#endif
+#ifndef HVAC_UART_RX
+#define HVAC_UART_RX -1
+#endif
+
 
 #define DEBUG_SERIAL_(x, x2) {if (SerialLog) {SerialLog->print(x); if (strlen(x2))SerialLog->print(x2);}}
 #define DEBUG_LOG(x) {DEBUG_SERIAL_(x, ""); mqttDebugLog(x);}
@@ -247,7 +254,7 @@ void setup() {
     // Allow Remote/Panel
     hp.enableExternalUpdate();
     hp.enableAutoUpdate();
-    if (hp.connect(SerialHvac)) {
+    if (hp.connect(SerialHvac, HVAC_UART_RX, HVAC_UART_TX)) {
       DEBUG_LOG_LN(F("Success"));
       heatpumpStatus currentStatus = hp.getStatus();
       heatpumpSettings currentSettings = hp.getSettings();
@@ -1330,7 +1337,7 @@ void write_log(String log) {
 
 heatpumpSettings change_states(heatpumpSettings settings) {
   if (server.hasArg("CONNECT")) {
-    hp.connect(SerialHvac);
+    hp.connect(SerialHvac, HVAC_UART_RX, HVAC_UART_TX);
   }
   else {
     bool update = false;


### PR DESCRIPTION
This MR contains a whole bunch of changes in separate commits, let me know if you'd prefer them split out into separate MR's.

* Allow specifying the UART number to use (ie different uart for debug and hvac connectsion).
* Allow specifying the particular uart TX  and RX pins for hvac
* Enable debug logging if hvac uart doesn't conflict.
* Send debug logging over mqtt as well (can be viewed in HA mqtt inspector)
* Add support for ESP32-S2-MINI
* Specify firmware binary name and display it on web upgrade page.
* Fix a couple of issues with the web control page.

This all started when I wanted to upgrade an older unit I had running and it took me a while to remember what hardware I used. I thought it'd be handy to show the correct / expected build on the firmware upgrade page, eg.
![image](https://github.com/gysmo38/mitsubishi2MQTT/assets/3318786/d83b26d9-a152-4029-b52d-9ae357f7865b)

I then wanted to test my changes on a separate esp32 module rather than the one tucked up in my aircon, but the only one I had handy was a newer esp32-s2, so I added support for that. 

The default `Serial` object on the S3 is the internal USB port, not a uart. So I added support for specifying the desired UART via: `build_flags = -DHVAC_UART=0`

Finally I was having some more issues so wanted serial logging; now that hvac can be configured to run on a separate uart, I decided to make debug logging automatically enabled if HVAC is on a different uart to the default Serial output.
