### PR TITLE
fix String returned from server::arg() dropping out of scope

### DIFF
--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1255,12 +1255,21 @@ heatpumpSettings change_states(heatpumpSettings settings) {
   }
   else {
     bool update = false;
+
+    String powerArg;
+    String modeArg;
+    String fanArg;
+    String vaneArg;
+    String widevaneArg;
+
     if (server.hasArg("POWER")) {
-      settings.power = server.arg("POWER").c_str();
+      powerArg = server.arg("POWER");
+      settings.power = powerArg.c_str();
       update = true;
     }
     if (server.hasArg("MODE")) {
-      settings.mode = server.arg("MODE").c_str();
+      modeArg = server.arg("MODE");
+      settings.mode = modeArg.c_str();
       update = true;
     }
     if (server.hasArg("TEMP")) {
@@ -1268,15 +1277,18 @@ heatpumpSettings change_states(heatpumpSettings settings) {
       update = true;
     }
     if (server.hasArg("FAN")) {
-      settings.fan = server.arg("FAN").c_str();
+      fanArg = server.arg("FAN");
+      settings.fan = fanArg.c_str();
       update = true;
     }
     if (server.hasArg("VANE")) {
-      settings.vane = server.arg("VANE").c_str();
+      vaneArg = server.arg("VANE");
+      settings.vane = vaneArg.c_str();
       update = true;
     }
     if (server.hasArg("WIDEVANE")) {
-      settings.wideVane = server.arg("WIDEVANE").c_str();
+      widevaneArg = server.arg("WIDEVANE");
+      settings.wideVane = widevaneArg.c_str();
       update = true;
     }
     if (update) {


### PR DESCRIPTION
### Problem
the `String` returned by the `server::arg` methods (like `server::arg("POWER")`) drops out of scope right after its `c_str()` method is called.

I'm using a ESP32. That implementation (https://github.com/espressif/arduino-esp32/blob/2.0.14/libraries/WebServer/src/WebServer.cpp#L549) returns a `String` by value, so once the `String` returned by `arg()` is out of scope, the underlying `c_str()` pointer becomes invalid.

Without this fix, this was causing the web interface to not take updates — by the time the HeatPump library tried to read the various argument strings they were reset.


### Fix
I'm not sure that this is a good fix, but it does work: keeping the returned `String` in scope until _after_ the `setSettings` call ensures that the underlying `char *` buffers aren't cleared.

Maybe a better fix would be to update the settings interface to support a String optionally somehow?

