### PR TITLE
Correct Fahrenheit/Celsius conversions to match MA Remote Controller

### DIFF
--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -33,6 +33,8 @@ ESP8266WebServer server(80);  // ESP8266 web
 #include <PubSubClient.h>     // MQTT: PubSubClient 2.8.0
 #include <DNSServer.h>        // DNS for captive portal
 #include <math.h>             // for rounding to Fahrenheit values
+#include <map>
+#include <cmath>              // For roundf function
 
 #include <ArduinoOTA.h>   // for OTA
 #include <HeatPump.h>     // SwiCago library: https://github.com/SwiCago/HeatPump

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -747,7 +747,7 @@ void handleUnit() {
   if (!checkLogin()) return;
 
   if (server.method() == HTTP_POST) {
-    saveUnit(server.arg("tu"), server.arg("md"), server.arg("lpw"), (String)convertLocalUnitToCelsius(server.arg("min_temp").toInt(), useFahrenheit), (String)convertLocalUnitToCelsius(server.arg("max_temp").toInt(), useFahrenheit), server.arg("temp_step"));
+    saveUnit(server.arg("tu"), server.arg("md"), server.arg("lpw"), (String)convertLocalUnitToCelsius(server.arg("min_temp").toFloat(), useFahrenheit), (String)convertLocalUnitToCelsius(server.arg("max_temp").toFloat(), useFahrenheit), server.arg("temp_step"));
     rebootAndSendPage();
   }
   else {
@@ -1264,7 +1264,7 @@ heatpumpSettings change_states(heatpumpSettings settings) {
       update = true;
     }
     if (server.hasArg("TEMP")) {
-      settings.temperature = convertLocalUnitToCelsius(server.arg("TEMP").toInt(), useFahrenheit);
+      settings.temperature = convertLocalUnitToCelsius(server.arg("TEMP").toFloat(), useFahrenheit);
       update = true;
     }
     if (server.hasArg("FAN")) {

--- a/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
+++ b/src/mitsubishi2mqtt/mitsubishi2mqtt.ino
@@ -1743,14 +1743,50 @@ bool connectWifi() {
   return true;
 }
 
-// temperature helper functions
-float toFahrenheit(float fromCelcius) {
-  return round(1.8 * fromCelcius + 32.0);
+// temperature helper these are direct mappings based on the remote
+float toFahrenheit(float fromCelsius) {
+    // Lookup table for specific mappings
+    const std::map<float, int> lookupTable = {
+        {16.0, 61}, {16.5, 62}, {17.0, 63}, {17.5, 64}, {18.0, 65},
+        {18.5, 66}, {19.0, 67}, {20.0, 68}, {21.0, 69}, {21.5, 70},
+        {22.0, 71}, {22.5, 72}, {23.0, 73}, {23.5, 74}, {24.0, 75},
+        {24.5, 76}, {25.0, 77}, {25.5, 78}, {26.0, 79}, {26.5, 80},
+        {27.0, 81}, {27.5, 82}, {28.0, 83}, {28.5, 84}, {29.0, 85},
+        {29.5, 86}, {30.0, 87}, {30.5, 88}
+    };
+
+    // Check if the input is in the lookup table
+    auto it = lookupTable.find(fromCelsius);
+    if (it != lookupTable.end()) {
+        return it->second;
+    }
+
+    // Default conversion and rounding to nearest integer
+    return roundf(fromCelsius * 1.8 + 32.0);
 }
 
+// temperature helper these are direct mappings based on the remote
 float toCelsius(float fromFahrenheit) {
-  return (fromFahrenheit - 32.0) / 1.8;
+    // Lookup table for specific mappings
+    const std::map<int, float> lookupTable = {
+        {61, 16.0}, {62, 16.5}, {63, 17.0}, {64, 17.5}, {65, 18.0},
+        {66, 18.5}, {67, 19.0}, {68, 20.0}, {69, 21.0}, {70, 21.5},
+        {71, 22.0}, {72, 22.5}, {73, 23.0}, {74, 23.5}, {75, 24.0},
+        {76, 24.5}, {77, 25.0}, {78, 25.5}, {79, 26.0}, {80, 26.5},
+        {81, 27.0}, {82, 27.5}, {83, 28.0}, {84, 28.5}, {85, 29.0},
+        {86, 29.5}, {87, 30.0}, {88, 30.5}
+    };
+
+    // Check if the input is in the lookup table
+    auto it = lookupTable.find(static_cast<int>(fromFahrenheit));
+    if (it != lookupTable.end()) {
+        return it->second;
+    }
+
+    // Default conversion and rounding to nearest 0.5
+    return roundf((fromFahrenheit - 32.0) / 1.8 * 2) / 2.0;
 }
+
 
 float convertCelsiusToLocalUnit(float temperature, bool isFahrenheit) {
   if (isFahrenheit) {


### PR DESCRIPTION
### Pull Request Summary: Improved Temperature Conversion Functions

#### Overview
This pull request enhances the `toCelsius` function to include precise mappings for specific Fahrenheit to Celsius conversions required by the project. It also introduces a new `toFahrenheit` function to map Celsius values back to Fahrenheit. The changes ensure that temperature conversions align with the desired setpoints for both IR remote control and MA Remote Dispaly.

#### Changes Made
1. **Enhanced `toCelsius` Function**:
   - Implemented a lookup table to map specific Fahrenheit values to their corresponding Celsius values.
   - Included mappings for the following Fahrenheit setpoints:
     - 61°F to 88°F in Fahrenheit setpoints incremented by 1°F.
     - Each mapping corresponds to the appropriate Celsius value (e.g., 72°F -> 22.5°C, 73°F -> 23.0°C).
   - The function defaults to a general conversion formula for values not explicitly listed in the table.

2. **Enhanced `toFahrenheit` Function**:
   - Created a reverse lookup table to map specific Celsius values back to their corresponding Fahrenheit values.
   - Included mappings for the following Celsius setpoints:
     - 16.0°C to 30.5°C in Celsius setpoints incremented by 0.5°C.
     - Each mapping corresponds to the appropriate Fahrenheit value (e.g., 22.5°C -> 72°F, 23.0°C -> 73°F).
   - The function defaults to a general conversion formula and rounds the result to the nearest integer for values not explicitly listed in the table.

#### Code Implementation
- **`toCelsius` Function**:
  ```cpp
  float toCelsius(float fromFahrenheit) {
      const std::map<int, float> lookupTable = {
          {61, 16.0}, {62, 16.5}, {63, 17.0}, {64, 17.5}, {65, 18.0},
          {66, 18.5}, {67, 19.0}, {68, 20.0}, {69, 21.0}, {70, 21.5},
          {71, 22.0}, {72, 22.5}, {73, 23.0}, {74, 23.5}, {75, 24.0},
          {76, 24.5}, {77, 25.0}, {78, 25.5}, {79, 26.0}, {80, 26.5},
          {81, 27.0}, {82, 27.5}, {83, 28.0}, {84, 28.5}, {85, 29.0},
          {86, 29.5}, {87, 30.0}, {88, 30.5}
      };

      auto it = lookupTable.find(static_cast<int>(fromFahrenheit));
      if (it != lookupTable.end()) {
          return it->second;
      }

      float result = (fromFahrenheit - 32.0) / 1.8;
      return round(result * 2) / 2.0;
  }
  ```

- **`toFahrenheit` Function**:
  ```cpp
  float toCustomFahrenheit(float fromCelsius) {
      const std::map<float, int> lookupTable = {
          {16.0, 61}, {16.5, 62}, {17.0, 63}, {17.5, 64}, {18.0, 65},
          {18.5, 66}, {19.0, 67}, {20.0, 68}, {21.0, 69}, {21.5, 70},
          {22.0, 71}, {22.5, 72}, {23.0, 73}, {23.5, 74}, {24.0, 75},
          {24.5, 76}, {25.0, 77}, {25.5, 78}, {26.0, 79}, {26.5, 80},
          {27.0, 81}, {27.5, 82}, {28.0, 83}, {28.5, 84}, {29.0, 85},
          {29.5, 86}, {30.0, 87}, {30.5, 88}
      };

      auto it = lookupTable.find(fromCelsius);
      if (it != lookupTable.end()) {
          return it->second;
      }

      return round(fromCelsius * 1.8 + 32.0);
  }
  ```

#### Impact
- **Accuracy**: Ensures precise temperature setpoints matching the IR remote control and MQTT requirements.
- **Maintainability**: Uses lookup tables for specific conversions, making the code easier to adjust for future requirements.
- **Consistency**: Both functions handle temperature conversions consistently, improving reliability in temperature control scenarios.

These improvements significantly enhance the functionality and reliability of temperature conversions within the codebase.